### PR TITLE
Version 0.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM nona/ffmpeg
+FROM nona/ffmpeg:0.0.11
 MAINTAINER Shaun Egan <shaun@nonacreative.com>
 
 RUN \
     apt-get update && \
     apt-get install -yq apt-utils && \
-    apt-get install -yq gcc make build-essential npm git && \
+    apt-get install -yq gcc make build-essential npm git curl && \
+    curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash - && \
+    apt-get install -y nodejs && \
     apt-get clean && \
     apt-get purge && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir /repositories && \
-    cd /repositories && \
-    git clone https://github.com/joyent/node.git && \
-    cd node && \
-    git checkout tags/v0.12.4 && \
-    ./configure && \
-    make && \
-    make install
+    rm -rf /var/lib/apt/lists/* 


### PR DESCRIPTION
Install node binaries instead of compiling from source.

Builds, like, way quicker now.
